### PR TITLE
Directly build and call network

### DIFF
--- a/CoTr_package/CoTr/network_architecture/DeTrans/position_encoding.py
+++ b/CoTr_package/CoTr/network_architecture/DeTrans/position_encoding.py
@@ -25,7 +25,7 @@ class PositionEmbeddingSine(nn.Module):
 
     def forward(self, x):
         bs, c, d, h, w = x.shape
-        mask = torch.zeros(bs, d, h, w, dtype=torch.bool).cuda()
+        mask = torch.zeros(bs, d, h, w, dtype=torch.bool).to(x.device)
         assert mask is not None
         not_mask = ~mask
         d_embed = not_mask.cumsum(1, dtype=torch.float32)

--- a/CoTr_package/CoTr/network_architecture/ResTranUnet.py
+++ b/CoTr_package/CoTr/network_architecture/ResTranUnet.py
@@ -208,3 +208,14 @@ class ResTranUnet(SegmentationNetwork):
             return seg_output
         else:
             return seg_output[0]
+if __name__ == '__main__':
+    
+    #test model directly
+    device=torch.device('cpu')
+    data=torch.randn((1,1,64,128,128)).to(device)
+    testmodel=U_ResTran3D(num_classes=2)
+    total = sum([param.nelement() for param in testmodel.parameters()])
+
+    print("Number of parameter: %.2fM" % (total / 1e6))
+   
+    print(testmodel(data)[0].size())

--- a/CoTr_package/CoTr/network_architecture/ResTranUnet.py
+++ b/CoTr_package/CoTr/network_architecture/ResTranUnet.py
@@ -135,7 +135,7 @@ class U_ResTran3D(nn.Module):
             if lvl > 1:
                 x_fea.append(fea)
                 x_posemb.append(self.position_embed(fea))
-                masks.append(torch.zeros((fea.shape[0], fea.shape[2], fea.shape[3], fea.shape[4]), dtype=torch.bool).cuda())
+                masks.append(torch.zeros((fea.shape[0], fea.shape[2], fea.shape[3], fea.shape[4]), dtype=torch.bool).to(x[0].device))
 
         return x_fea, masks, x_posemb
 


### PR DESCRIPTION
In the process of using other data sets, we want to find the network structure directly. It is found that the network is directly defined on the GPU, which may affect the network modification test or the performance under the condition of multiple GPUs.